### PR TITLE
Fix T1 fit error when using recent package releases

### DIFF
--- a/blood_tools/blood_relax_tool.py
+++ b/blood_tools/blood_relax_tool.py
@@ -679,11 +679,7 @@ class MainWindow(QtWidgets.QWidget):
             ti = np.array(ti)  # necessary for the next line to work
             if 20000 not in ti:
                 T1_guess = -ti[np.where(signal == signal.min())] / np.log(0.5)
-                if(np.size(T1_guess) > 1):
-                    inversion_recovery['T1'] = T1_guess[0]
-                else:
-                    inversion_recovery['T1'] = T1_guess
-                    
+                inversion_recovery['T1'] = T1_guess[0]        
                 inversion_recovery['B']=2*signal.max()        
 
             bootstrap_signals = bootstrap_decay_signal(


### PR DESCRIPTION
When using recent python package releases (listed below), attempting to perform a T1 fit of the images and ROI in examples/T1_demo using the code in commit [2ca7971](https://github.com/shportnoy/blood_roi_tool/commit/2ca7971baa8418a2461bdc606500a484bbbc5261) results in an error that reads "_Cannot cast array data from dtype('O') to dtype('float64') according to the rule 'safe'_". This appears to occur because the [`pars` variable in blood_tools/fitting.py](https://github.com/shportnoy/blood_roi_tool/blob/2ca7971baa8418a2461bdc606500a484bbbc5261/blood_tools/fitting.py#L207) is a list with three elements, the first two being float64 and the last a one-element ndarray, which itself is a float64 (e.g., `[1308.67, 2617.33, array([1762.97])]`) and then the [call to scipy.optimize.curve_fit in blood_tools/fitting.py](https://github.com/shportnoy/blood_roi_tool/blob/2ca7971baa8418a2461bdc606500a484bbbc5261/blood_tools/fitting.py#L220) leads to the error. It may be that some type checking has been built in to scipy, but the exact nature of the error is unclear to me.

Avoid setting the third element in `pars` to an ndarray seems to avoid the error and is compatible with older packages. Assuming there is never more than one unique value of []`T1_guess` in blood_tools/blood_relax_tool.py](https://github.com/shportnoy/blood_roi_tool/blob/2ca7971baa8418a2461bdc606500a484bbbc5261/blood_tools/blood_relax_tool.py#L681), a simple change in the subsequent lines of code to set `inversion_recovery['T1'] = T1_guess[0]` regardless of the size of `T1_guess` ensures the third element in `pars` is not an ndarray and, consequently, avoids the "cannot cast array data..." error. 

---

Environment (`conda list`) with recent packges where error occurs using commit [2ca7971](https://github.com/shportnoy/blood_roi_tool/commit/2ca7971baa8418a2461bdc606500a484bbbc5261):
```
# Name                    Version                   Build  Channel
_libgcc_mutex             0.1                        main  
blas                      1.0                         mkl  
blood-tools               0.0.1                    pypi_0    pypi
ca-certificates           2020.1.1                      0  
certifi                   2019.11.28               py38_1  
cloudpickle               1.3.0                      py_0  
cycler                    0.10.0                   py38_0  
cytoolz                   0.10.1           py38h7b6447c_0  
dask-core                 2.13.0                     py_0  
dbus                      1.13.12              h746ee38_0  
decorator                 4.4.2                      py_0  
expat                     2.2.6                he6710b0_0  
fastcache                 1.1.0            py38h7b6447c_0  
fontconfig                2.13.0               h9420a91_0  
freetype                  2.9.1                h8a8886c_1  
glib                      2.63.1               h5a9c865_0  
gmp                       6.1.2                h6c8ec71_1  
gmpy2                     2.0.8            py38hd5f6e3b_3  
gst-plugins-base          1.14.0               hbbd80ab_1  
gstreamer                 1.14.0               hb453b48_1  
icu                       58.2                 h9c2bf20_1  
imageio                   2.8.0                      py_0  
intel-openmp              2020.0                      166  
jpeg                      9b                   h024ee3a_2  
kiwisolver                1.0.1            py38he6710b0_0  
ld_impl_linux-64          2.33.1               h53a641e_7  
libedit                   3.1.20181209         hc058e9b_0  
libffi                    3.2.1                hd88cf55_4  
libgcc-ng                 9.1.0                hdf63c60_0  
libgfortran-ng            7.3.0                hdf63c60_0  
libpng                    1.6.37               hbc83047_0  
libstdcxx-ng              9.1.0                hdf63c60_0  
libtiff                   4.1.0                h2733197_0  
libuuid                   1.0.3                h1bed415_2  
libxcb                    1.13                 h1bed415_1  
libxml2                   2.9.9                hea5a465_1  
matplotlib                3.1.3                    py38_0  
matplotlib-base           3.1.3            py38hef1b27d_0  
mkl                       2020.0                      166  
mkl-service               2.3.0            py38he904b0f_0  
mkl_fft                   1.0.15           py38ha843d7b_0  
mkl_random                1.1.0            py38h962f231_0  
mpc                       1.1.0                h10f8cd9_1  
mpfr                      4.0.1                hdf1c602_3  
mpmath                    1.1.0                    py38_0  
ncurses                   6.2                  he6710b0_0  
networkx                  2.4                        py_0  
numexpr                   2.7.1            py38h423224d_0  
numpy                     1.18.1           py38h4f9e942_0  
numpy-base                1.18.1           py38hde5b4d6_1  
olefile                   0.46                       py_0  
openssl                   1.1.1e               h7b6447c_0  
pcre                      8.43                 he6710b0_0  
pillow                    7.0.0            py38hb39fc2d_0  
pip                       20.0.2                   py38_1  
pydicom                   1.4.2                      py_0    conda-forge
pyparsing                 2.4.6                      py_0  
pyqt                      5.9.2            py38h05f1152_4  
python                    3.8.2                hcf32534_0  
python-dateutil           2.8.1                      py_0  
pywavelets                1.1.1            py38h7b6447c_0  
qt                        5.9.7                h5867ecd_1  
qtawesome                 0.7.0                      py_0  
qtpy                      1.9.0                      py_0  
readline                  8.0                  h7b6447c_0  
scikit-image              0.16.2           py38h0573a6f_0  
scipy                     1.4.1            py38h0b6359f_0  
setuptools                46.1.1                   py38_0  
sip                       4.19.13          py38he6710b0_0  
six                       1.14.0                   py38_0  
sqlite                    3.31.1               h7b6447c_0  
sympy                     1.5.1                    py38_0  
tk                        8.6.8                hbc83047_0  
toolz                     0.10.0                     py_0  
tornado                   6.0.4            py38h7b6447c_1  
wheel                     0.34.2                   py38_0  
xz                        5.2.4                h14c3975_4  
zlib                      1.2.11               h7b6447c_3  
zstd                      1.3.7                h0b5b093_0  
```

Environment (`conda list`) with less-recent packages where __no__ error occurs using commit [2ca7971](https://github.com/shportnoy/blood_roi_tool/commit/2ca7971baa8418a2461bdc606500a484bbbc5261):
```
# Name                    Version                   Build  Channel
_libgcc_mutex             0.1                        main  
backports                 1.0                        py_2  
backports.functools_lru_cache 1.6.1                      py_0  
backports_abc             0.5                      py27_0  
blas                      1.0                         mkl  
blood-tools               0.0.1                    pypi_0    pypi
bokeh                     1.4.0                    py27_0  
ca-certificates           2020.1.1                      0  
certifi                   2019.11.28               py27_0  
click                     7.1.1                      py_0  
cloudpickle               1.2.2                      py_0  
cycler                    0.10.0                   py27_0  
cytoolz                   0.10.1           py27h7b6447c_0  
dask                      1.2.2                      py_0  
dask-core                 1.2.2                      py_0  
dbus                      1.13.12              h746ee38_0  
decorator                 4.4.2                      py_0  
distributed               1.28.1                   py27_0  
enum34                    1.1.6                    py27_1  
expat                     2.2.6                he6710b0_0  
fastcache                 1.1.0            py27h7b6447c_0  
fontconfig                2.12.6               h49f89f6_0  
freetype                  2.8                  hab7d2ae_1  
functools32               3.2.3.2                  py27_1  
futures                   3.3.0                    py27_0  
glib                      2.63.1               h5a9c865_0  
gmp                       6.1.2                h6c8ec71_1  
gmpy2                     2.0.8            py27h10f8cd9_2  
gst-plugins-base          1.12.4               h33fb286_0  
gstreamer                 1.12.4               hb53b477_0  
heapdict                  1.0.1                      py_0  
icu                       58.2                 h9c2bf20_1  
imageio                   2.6.1                    py27_0  
intel-openmp              2019.4                      243  
jinja2                    2.11.1                     py_0  
jpeg                      9b                   h024ee3a_2  
libedit                   3.1.20181209         hc058e9b_0  
libffi                    3.2.1                hd88cf55_4  
libgcc-ng                 9.1.0                hdf63c60_0  
libgfortran-ng            7.3.0                hdf63c60_0  
libpng                    1.6.37               hbc83047_0  
libstdcxx-ng              9.1.0                hdf63c60_0  
libtiff                   4.1.0                h2733197_0  
libxcb                    1.13                 h1bed415_1  
libxml2                   2.9.9                hea5a465_1  
locket                    0.2.0                    py27_1  
markupsafe                1.1.1            py27h7b6447c_0  
matplotlib                2.1.1            py27h0128e01_0  
mkl                       2018.0.3                      1  
mkl_fft                   1.0.6            py27h7dd41cf_0  
mkl_random                1.0.1            py27h4414c95_1  
mpc                       1.1.0                h10f8cd9_1  
mpfr                      4.0.1                hdf1c602_3  
mpmath                    1.1.0                    py27_0  
msgpack-python            0.6.1            py27hfd86e86_1  
ncurses                   6.2                  he6710b0_0  
networkx                  2.2                      py27_1  
numexpr                   2.6.4            py27hd318778_0  
numpy                     1.14.2           py27hdbf6ddf_1  
olefile                   0.46                     py27_0  
openssl                   1.0.2u               h7b6447c_0  
packaging                 20.3                       py_0  
pandas                    0.24.2           py27he6710b0_0  
partd                     1.0.0                      py_0  
pcre                      8.43                 he6710b0_0  
pillow                    5.1.0            py27h3deb7b8_0  
pip                       19.3.1                   py27_0  
psutil                    5.6.7            py27h7b6447c_0  
pydicom                   0.9.9                    py27_0    conda-forge
pyparsing                 2.4.6                      py_0  
pyqt                      5.6.0            py27h22d08a2_6  
python                    2.7.15               h77bded6_2  
python-dateutil           2.8.1                      py_0  
pytz                      2019.3                     py_0  
pywavelets                1.0.3            py27hdd07704_1  
pyyaml                    5.2              py27h7b6447c_0  
qt                        5.6.2               hd25b39d_14  
qtawesome                 0.4.4                    py27_0  
qtpy                      1.3.1            py27h63d3751_0  
readline                  7.0                  h7b6447c_5  
scikit-image              0.13.1           py27h14c3975_1  
scipy                     1.0.0            py27hf5f0f52_0  
setuptools                44.0.0                   py27_0  
singledispatch            3.4.0.3                  py27_0  
sip                       4.18.1           py27hf484d3e_2  
six                       1.11.0                   py27_1  
sortedcontainers          2.1.0                    py27_0  
sqlite                    3.31.1               h7b6447c_0  
subprocess32              3.5.4            py27h7b6447c_0  
sympy                     1.1.1                    py27_0  
tblib                     1.6.0                      py_0  
tk                        8.6.8                hbc83047_0  
toolz                     0.10.0                     py_0  
tornado                   5.1.1            py27h7b6447c_0  
wheel                     0.33.6                   py27_0  
xz                        5.2.4                h14c3975_4  
yaml                      0.1.7                had09818_2  
zict                      2.0.0                      py_0  
zlib                      1.2.11               h7b6447c_3  
zstd                      1.3.7                h0b5b093_0  
```